### PR TITLE
chore: release v0.1.0-alpha0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0-alpha0](https://github.com/smohekey/syntacks/releases/tag/v0.1.0-alpha0) - 2024-09-22
+
+### Other
+
+- Renamed package.
+- Added github actions
+- A few small tidy ups.
+- Populate package fields of Cargo.toml
+- Modified README
+- Remove extraneous LICENSE file
+- Merge remote-tracking branch 'origin/main'
+- Initial commit


### PR DESCRIPTION
## 🤖 New release
* `syntacks`: 0.1.0-alpha0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha0](https://github.com/smohekey/syntacks/releases/tag/v0.1.0-alpha0) - 2024-09-22

### Other

- Renamed package.
- Added github actions
- A few small tidy ups.
- Populate package fields of Cargo.toml
- Modified README
- Remove extraneous LICENSE file
- Merge remote-tracking branch 'origin/main'
- Initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).