### PR TITLE
chore: release v0.1.0-alpha0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha0.2](https://github.com/smohekey/syntacks/compare/v0.1.0-alpha0.1...v0.1.0-alpha0.2) - 2024-09-22
+
+### Other
+
+- Fixed url in build badge.
+- Merge branch 'main' of https://github.com/smohekey/syntacks
+- Added dependabot and an additional badge
+
 ## [0.1.0-alpha0.1](https://github.com/smohekey/syntacks/compare/v0.1.0-alpha0...v0.1.0-alpha0.1) - 2024-09-22
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
 
 [[package]]
 name = "syntacks"
-version = "0.1.0-alpha0.1"
+version = "0.1.0-alpha0.2"
 dependencies = [
  "async-stream",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 name = "syntacks"
 readme = "README.md"
 repository = "https://github.com/smohekey/syntax"
-version = "0.1.0-alpha0.1"
+version = "0.1.0-alpha0.2"
 
 [dependencies]
 async-stream = "0.3.5"


### PR DESCRIPTION
## 🤖 New release
* `syntacks`: 0.1.0-alpha0.1 -> 0.1.0-alpha0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.0-alpha0.2](https://github.com/smohekey/syntacks/compare/v0.1.0-alpha0.1...v0.1.0-alpha0.2) - 2024-09-22

### Other

- Fixed url in build badge.
- Merge branch 'main' of https://github.com/smohekey/syntacks
- Added dependabot and an additional badge
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).